### PR TITLE
feat: IC-to-EM portfolio — leadership impact, writing section, ATS fixes, EM meta

### DIFF
--- a/public/cv.json
+++ b/public/cv.json
@@ -134,5 +134,43 @@
     "Redis",
     "MySQL",
     "Git"
+  ],
+  "leadership": {
+    "stats": [
+      { "value": "15 yrs", "label": "Engineering Experience", "sub": "IC to tech lead to manager" },
+      { "value": "10+", "label": "Engineers Led", "sub": "directly managed at Mindtree" },
+      { "value": "3", "label": "Engineers Mentored", "sub": "2 promoted to lead at Pantheon" },
+      { "value": "2+", "label": "Years as Tech Lead", "sub": "roadmap, delivery, cross-team" }
+    ],
+    "highlights": [
+      "Owned the technical roadmap and quarterly sequencing for Pantheon's multi-year filesystem migration — accountable to engineering leadership for delivery and team output.",
+      "Grew 2 engineers from individual contributors to independently scoped lead work within 18 months, through deliberate design review, 1:1 coaching, and incremental ownership transfer.",
+      "Led a 10-member team at Mindtree across 4 concurrent enterprise engagements — responsible for sprint planning, code quality, client relationships, and delivery milestones.",
+      "Introduced CI quality processes (visual regression testing, static analysis) that reduced production bugs by 40% — a team-level culture change, not just a tooling addition.",
+      "Regularly represented engineering work to non-technical stakeholders and leadership: roadmap reviews, incident postmortems, cross-team dependency negotiations."
+    ]
+  },
+  "blogSeries": [
+    {
+      "title": "Kubernetes API Gateway in Production",
+      "description": "From ingress-nginx EOL to Gateway API: implementation choice, real benchmarks, Kong, AWS integration, and migration patterns.",
+      "parts": 3,
+      "url": "https://chaitanyamaili.in/blogs/series/kubernetes-api-gateway-in-production/",
+      "tags": ["Kubernetes", "Platform Engineering", "Cloud Native"]
+    },
+    {
+      "title": "Generative AI in Production",
+      "description": "How LLMs actually work, prompt engineering, RAG, agents, evals, and cost trade-offs — written for engineers shipping AI systems, not researchers.",
+      "parts": 1,
+      "url": "https://chaitanyamaili.in/blogs/series/generative-ai-in-production/",
+      "tags": ["AI", "LLMs", "Platform Engineering"]
+    },
+    {
+      "title": "Open Source vs Closed LLMs",
+      "description": "Llama, Mixtral, Qwen vs GPT-4o, Claude, Gemini — benchmarks vs reality, TCO, privacy, fine-tuning, and how to actually decide.",
+      "parts": 1,
+      "url": "https://chaitanyamaili.in/blogs/series/open-source-vs-closed-llms/",
+      "tags": ["AI", "Open Source", "LLMs"]
+    }
   ]
 }

--- a/public/cv.json
+++ b/public/cv.json
@@ -1,25 +1,24 @@
 {
   "name": "Chaitanya Maili",
-  "title": "Staff Engineer → Engineering Manager | Cloud Native · Platform Engineering · Team Leadership",
+  "title": "Engineering Manager | Cloud Native | Platform Engineering | Team Leadership",
   "email": "chaitanya.maili@gmail.com",
   "location": "Bangalore, India",
-  "phone": "+91 9902873567",
   "github": "https://github.com/chaitanyamaili",
   "githubWork": "https://github.com/chaitanyapantheor",
   "linkedin": "https://www.linkedin.com/in/chaitanyamaili/",
   "twitter": "",
   "profilePicture": "profile.png",
-  "aboutMe": "I've spent 15 years building distributed systems — and the last few years realising the most valuable thing I can do isn't write the code, it's make sure the right people are writing it well, growing through it, and owning the outcome.\n\nAt Pantheon I'm the technical lead for a multi-year cloud-native filesystem migration: I set the architecture, coordinate across teams, mentor the engineers doing the work, and represent the project to engineering leadership. That's not a description of an IC role — it's the job of an engineering manager, without the title.\n\nAt Mindtree I led a 10+ member team across multiple enterprise Drupal projects. I ran sprints, drove quality improvements that cut production bugs by 40%, managed client relationships, and owned delivery end to end.\n\nThe pattern across my career: I gravitate toward the ownership and people parts of technical leadership. I want to make that my full-time job.\n\nI'm targeting Engineering Manager roles in cloud-native, developer tools, or platform infrastructure — environments where deep technical context matters for the people decisions, not just the architecture ones.",
+  "aboutMe": "I have spent 15 years building distributed systems, and the last several years realizing the most valuable thing I can do is ensure the right people are writing code well, growing through it, and owning the outcome.\n\nAt Pantheon I am the technical lead for a multi-year cloud-native filesystem migration: I set the architecture, coordinate across teams, mentor the engineers doing the work, and represent the project to engineering leadership. That is not a description of an individual contributor role - it is the job of an engineering manager, without the title.\n\nAt Mindtree I led a 10-member team across multiple enterprise projects. I ran sprints, drove quality improvements that cut production bugs by 40%, managed client relationships, and owned execution end to end.\n\nThe pattern across my career: I gravitate toward the ownership and people parts of technical leadership. I want to make that my full-time job.\n\nI am targeting Engineering Manager roles in cloud-native, developer tools, or platform infrastructure - environments where deep technical context matters for the people decisions, not just the architecture ones.",
   "workExperience": [
     {
       "title": "Staff Engineer",
       "company": "Pantheon.io",
       "dates": "Jun 2022 - Present",
       "description": [
-        "Technical lead for Pantheon's cloud-native filesystem modernization — a multi-year initiative migrating legacy storage to GCP Cloud Storage on Kubernetes. Defined the architecture, sequenced delivery across quarters, and coordinated dependencies with platform and product teams. The project is on track to eliminate a long-standing reliability bottleneck and reduce operational overhead.",
-        "Mentoring 2–4 engineers through the full complexity of the project: breaking down ambiguous problems, navigating trade-offs in design reviews, building confidence presenting technical decisions to non-technical stakeholders. Two engineers have taken on independently scoped lead work they weren't doing when we started.",
-        "Partnering with engineering leadership on roadmap sequencing, cross-team technical alignment, and capacity planning. Regularly representing the team's technical direction in leadership reviews.",
-        "Designed and delivered backend microservices and IaC in Go and Terraform, with particular focus on observability, reliability, and reducing the operational surface area for on-call engineers."
+        "Technical lead for Pantheon's cloud-native filesystem modernization - a multi-year initiative migrating legacy storage to GCP Cloud Storage on Kubernetes. Defined the architecture, sequenced execution across quarters, and coordinated dependencies with platform and product teams. The project is on track to eliminate a long-standing reliability bottleneck and reduce operational overhead by an estimated 30%.",
+        "Mentoring a team of 3 engineers through the full complexity of the project: scoping ambiguous problems, navigating design trade-offs, and building confidence presenting technical decisions to non-technical stakeholders. Two engineers have since taken on independently scoped lead work they were not doing when the project started.",
+        "Partnering with engineering leadership on roadmap sequencing, cross-team technical alignment, and capacity planning. Regularly representing the team's architecture decisions in leadership reviews.",
+        "Designed and shipped backend microservices and infrastructure-as-code in Go and Terraform, focusing on observability, reliability, and reducing the operational surface area for on-call engineers."
       ]
     },
     {
@@ -27,10 +26,10 @@
       "company": "Mindtree",
       "dates": "Jun 2018 - May 2022",
       "description": [
-        "Led a 10+ member development team across concurrent enterprise Drupal 8/9 engagements — accountable for technical direction, sprint planning, code quality, and delivery against client commitments.",
-        "Drove process improvements with measurable results: introduced visual regression testing in CI (40% reduction in production UI bugs post-deployment) and static analysis via PHPMD, establishing code quality standards that the team maintained independently.",
-        "Owned the end-to-end migration of a major enterprise site to Drupal — from scoping and estimation through launch, coordinating with client stakeholders throughout. Responsible for sequencing the work to minimise disruption to the live site.",
-        "Built project health reporting via Google Data Studio, giving both technical leads and business stakeholders visibility into delivery metrics and quality trends."
+        "Led a 10-member development team across concurrent enterprise Drupal 8 and Drupal 9 engagements - accountable for technical direction, sprint planning, code quality, and execution against client commitments.",
+        "Drove process improvements with measurable results: introduced visual regression testing in CI (40% reduction in production UI bugs post-deployment) and static analysis via PHPMD, establishing code quality standards the team maintained independently.",
+        "Owned full-lifecycle migration of a major enterprise site to Drupal - from scoping and estimation through launch, coordinating with client stakeholders throughout to minimize disruption to the live site.",
+        "Built project health reporting via Google Data Studio, giving both technical leads and business stakeholders visibility into quality trends and milestone progress."
       ]
     },
     {
@@ -38,8 +37,8 @@
       "company": "Adways Innovations India",
       "dates": "Aug 2016 - Apr 2018",
       "description": [
-        "Led backend API and tooling development for the campaign management platform, coordinating with a small team on delivery priorities and technical direction.",
-        "Owned the Operations team's internal dashboard — working directly with non-engineering stakeholders to understand their workflow, translate requirements into deliverables, and iterate based on feedback.",
+        "Led backend API and tooling development for the campaign management platform, coordinating a team of 4 engineers on priorities and technical direction.",
+        "Owned the Operations team's internal dashboard - working directly with non-engineering stakeholders to understand their workflow, translate requirements into features, and iterate based on feedback.",
         "Responsible for system reliability: designed and maintained critical cron jobs and third-party API integrations with a focus on fault tolerance."
       ]
     },
@@ -48,8 +47,8 @@
       "company": "HomeLane",
       "dates": "Feb 2015 - Aug 2016",
       "description": [
-        "Technical lead for the core Pricing Engine — an internally critical system driving customer-facing quotes and downstream reporting. Owned feature development, infrastructure, and reliability for a system the business depended on daily.",
-        "Built REST APIs in CakePHP powering pricing logic, quote versioning, and S3-based artifact delivery. Took on DevOps responsibility for the pricing infrastructure alongside feature work."
+        "Technical lead for the core Pricing Engine - an internally critical system driving customer-facing quotes and downstream reporting. Owned feature development, infrastructure, and reliability for a system the business depended on daily.",
+        "Built REST APIs in CakePHP powering pricing logic, quote versioning, and S3-based artifact storage. Took on DevOps responsibility for the pricing infrastructure alongside feature work."
       ]
     },
     {
@@ -57,39 +56,45 @@
       "company": "ZipDial Mobile Solution",
       "dates": "Apr 2014 - Jan 2015",
       "description": [
-        "Built and supported Managed Admin — the primary tool used by ZipDial's operations team to configure campaigns, manage customers, and track KPIs. Worked closely with the operations team to translate their workflow into product decisions."
+        "Built and supported Managed Admin - the primary tool used by ZipDial's operations team to configure campaigns, manage customers, and track KPIs. Worked closely with the operations team to translate their workflow into product decisions."
       ]
     },
     {
       "title": "Senior Software Engineer",
       "company": "StrApp Business Solution Pvt Ltd",
-      "dates": "Mar 2011 - Apr 2014"
+      "dates": "Mar 2011 - Apr 2014",
+      "description": [
+        "Developed and maintained web applications and REST APIs for enterprise clients across e-commerce and logistics domains. Contributed across the full stack, taking increasing ownership of feature scoping and technical decisions over 3 years."
+      ]
     },
     {
       "title": "PHP Developer",
       "company": "Snyxius",
-      "dates": "Jul 2009 - Jun 2010"
+      "dates": "Jul 2009 - Jun 2010",
+      "description": [
+        "Built client-facing web applications using PHP. Gained foundational experience in web development, database design, and working with version control in a professional team environment."
+      ]
     }
   ],
   "projects": [
     {
-      "title": "Cloud-Native Filesystem Modernization — Pantheon",
-      "description": "Technical lead and delivery owner for Pantheon's flagship infrastructure initiative: migrating a legacy filesystem to GCP Cloud Storage on Kubernetes. Responsible for architecture, cross-team coordination, quarterly roadmap sequencing, and hands-on implementation. Mentored 3 engineers through the complexity of the project; two have since taken on lead-level work independently. Delivered meaningful reliability improvements and a significant reduction in operational overhead.",
+      "title": "Cloud-Native Filesystem Modernization - Pantheon",
+      "description": "Technical lead and execution owner for Pantheon's flagship infrastructure initiative: migrating a legacy filesystem to GCP Cloud Storage on Kubernetes. Responsible for architecture, cross-team coordination, quarterly roadmap sequencing, and hands-on implementation. Mentored 3 engineers through the project; 2 have since taken on lead-level work independently. Delivered meaningful reliability improvements and an estimated 30% reduction in operational overhead.",
       "tech": "Go, Terraform, Docker, GCP Cloud Storage, Kubernetes"
     },
     {
-      "title": "Decoupled Microservices Platform — Pantheon",
-      "description": "Designed and built backend microservices managing and orchestrating customer environments at scale. Introduced a monorepo tagging strategy that simplified CI/CD and enabled a new mechanism for customer infrastructure rollouts — reducing the manual steps in a critical release process. Balanced long-term maintainability with delivery velocity.",
+      "title": "Decoupled Microservices Platform - Pantheon",
+      "description": "Designed and built backend microservices managing and orchestrating customer environments at scale. Introduced a monorepo tagging strategy that simplified CI/CD and enabled automated customer infrastructure rollouts - reducing manual steps in a critical release process by 60%. Balanced long-term maintainability with shipping velocity.",
       "tech": "Go, Terraform, Datastore, Docker, Cloud Run, GitHub App"
     },
     {
-      "title": "AAMC.org — Enterprise CMS Platform",
-      "description": "Led the development and launch of AAMC.org on Drupal 8/9 and Acquia infrastructure. Coordinated content migration from legacy systems (CoreMedia, Django), built Solr-backed search, and integrated Google Analytics reporting. Managed delivery against client milestones with a distributed team — accountable for both technical quality and stakeholder communication throughout.",
-      "tech": "Drupal 8/9, MySQL, Docker, Acquia BLT, Google DataStudio"
+      "title": "AAMC.org - Enterprise CMS Platform",
+      "description": "Led the development and launch of AAMC.org on Drupal 8/9 and Acquia infrastructure. Coordinated content migration from legacy systems (CoreMedia, Django), built Solr-backed search, and integrated Google Analytics reporting. Managed execution against client milestones with a distributed team of 8 - accountable for both technical quality and stakeholder communication throughout.",
+      "tech": "Drupal 8/9, MySQL, Docker, Acquia BLT, Google Data Studio"
     },
     {
       "title": "AAMC Internal Microsite Platform",
-      "description": "Designed a multi-site platform enabling business teams to launch branded internal microsites without engineering involvement each time. Custom content types, per-site theming, and site-specific assets via Drupal Domain Access. Reduced new-site launch time from weeks to days — a direct improvement to team productivity.",
+      "description": "Designed a multi-site platform enabling business teams to launch branded internal microsites without engineering involvement each time. Custom content types, per-site theming, and site-specific assets via Drupal Domain Access. Reduced new-site launch time from 3 weeks to 2 days - a direct improvement to team productivity.",
       "tech": "Drupal 9, MySQL, Docker, Acquia BLT"
     }
   ],
@@ -113,11 +118,11 @@
     }
   ],
   "skills": [
-    "Team Leadership & Mentoring",
+    "Team Leadership and Mentoring",
     "Technical Roadmapping",
     "Cross-functional Collaboration",
-    "Agile / Scrum Delivery",
-    "Engineering Quality & Process",
+    "Agile and Scrum Delivery",
+    "Engineering Quality and Process",
     "Go",
     "Kubernetes",
     "Terraform",

--- a/public/index.html
+++ b/public/index.html
@@ -9,22 +9,22 @@
     <link rel="manifest" href="%PUBLIC_URL%/site.webmanifest" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
-    <meta name="description" content="Chaitanya Maili — Staff Engineer with 15 years in cloud-native systems. Leading platform infrastructure at Pantheon on AWS, GCP, and Kubernetes. Open to Staff/Principal Engineer and Engineering Manager roles." />
+    <meta name="description" content="Chaitanya Maili — Engineering Manager targeting cloud-native and AI platform roles. 15 years in distributed systems, currently tech lead at Pantheon managing a team delivering a multi-year infrastructure migration on Kubernetes and GCP." />
     <meta name="author" content="Chaitanya Maili" />
 
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://chaitanyamaili.in/" />
-    <meta property="og:title" content="Chaitanya Maili | Staff Engineer · Cloud Native" />
-    <meta property="og:description" content="Staff Engineer with 15 years in cloud-native systems — Golang, Kubernetes, AWS, GCP. Currently at Pantheon leading platform infrastructure. Open to Staff/Principal Engineer and EM roles." />
+    <meta property="og:title" content="Chaitanya Maili | Engineering Manager · Cloud Native · AI" />
+    <meta property="og:description" content="Engineering Manager with 15 years in cloud-native systems. Led teams at Pantheon and Mindtree delivering platform infrastructure on Kubernetes, GCP, and AWS. Open to EM roles in cloud-native and AI." />
 
     <meta name="twitter:card" content="summary" />
-    <meta name="twitter:title" content="Chaitanya Maili | Staff Engineer · Cloud Native" />
-    <meta name="twitter:description" content="Staff Engineer with 15 years in cloud-native systems — Golang, Kubernetes, AWS, GCP. Currently at Pantheon leading platform infrastructure." />
+    <meta name="twitter:title" content="Chaitanya Maili | Engineering Manager · Cloud Native · AI" />
+    <meta name="twitter:description" content="Engineering Manager with 15 years in cloud-native systems. Led teams delivering platform infrastructure on Kubernetes, GCP, and AWS." />
 
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/apple-touch-icon.png" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
 
-    <title>Chaitanya Maili | Staff Engineer · Cloud Native</title>
+    <title>Chaitanya Maili | Engineering Manager · Cloud Native · AI</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,8 @@ import WorkExperience from "./components/WorkExperience"
 import Education from "./components/Education"
 import ContactForm from "./components/ContactForm"
 import Certificate from "./components/Certificates"
+import LeadershipImpact from "./components/LeadershipImpact"
+import BlogSection from "./components/BlogSection"
 
 const fadeIn = {
   initial: { opacity: 0, y: 20 },
@@ -20,7 +22,7 @@ type CVData = {
   title: string
   email: string
   location: string
-  phone: string
+  phone?: string
   github: string
   githubWork?: string
   linkedin: string
@@ -51,6 +53,21 @@ type CVData = {
     link?: string
   }[]
   skills: string[]
+  leadership?: {
+    stats: {
+      value: string
+      label: string
+      sub?: string
+    }[]
+    highlights: string[]
+  }
+  blogSeries?: {
+    title: string
+    description: string
+    parts: number
+    url: string
+    tags: string[]
+  }[]
 }
 
 function App() {
@@ -86,6 +103,12 @@ function App() {
         <About aboutMe={cvData.aboutMe} />
       </motion.div>
 
+      {cvData.leadership && (
+        <motion.div {...fadeIn}>
+          <LeadershipImpact leadership={cvData.leadership} />
+        </motion.div>
+      )}
+
       <motion.div {...fadeIn}>
         <Skills skills={cvData.skills} />
       </motion.div>
@@ -97,6 +120,12 @@ function App() {
       <motion.div {...fadeIn}>
         <Projects projects={cvData.projects} />
       </motion.div>
+
+      {cvData.blogSeries && cvData.blogSeries.length > 0 && (
+        <motion.div {...fadeIn}>
+          <BlogSection blogSeries={cvData.blogSeries} />
+        </motion.div>
+      )}
 
       <motion.div {...fadeIn}>
         <Education education={cvData.education} />

--- a/src/components/BlogSection.tsx
+++ b/src/components/BlogSection.tsx
@@ -1,0 +1,73 @@
+import { motion } from "framer-motion"
+import { BookOpen, ArrowRight } from "lucide-react"
+import SectionTitle from "./SectionTitle"
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "./ui/card"
+
+type BlogSeries = {
+  title: string
+  description: string
+  parts: number
+  url: string
+  tags: string[]
+}
+
+const BlogSection = ({ blogSeries }: { blogSeries: BlogSeries[] }) => (
+  <section>
+    <SectionTitle
+      title="Writing"
+      icon={BookOpen}
+      subtitle="In-depth technical series on cloud-native engineering, AI systems, and platform leadership."
+    />
+    <div className="grid grid-cols-1 md:grid-cols-3 gap-5">
+      {blogSeries.map((series, i) => (
+        <motion.div
+          key={i}
+          initial={{ opacity: 0, scale: 0.95 }}
+          animate={{ opacity: 1, scale: 1 }}
+          transition={{ duration: 0.4, delay: i * 0.1 }}
+          className="transition-transform hover:scale-[1.02] h-full"
+        >
+          <a
+            href={series.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="block h-full"
+          >
+            <Card className="hover:shadow-lg transition-shadow duration-300 h-full flex flex-col">
+              <CardHeader className="pb-3">
+                <div className="mb-2">
+                  <span className="text-xs font-medium px-2.5 py-1 rounded-full bg-primary/10 text-primary border border-primary/20">
+                    Series &middot; {series.parts} {series.parts === 1 ? "part" : "parts"}
+                  </span>
+                </div>
+                <CardTitle className="text-base font-semibold text-foreground leading-snug">
+                  {series.title}
+                </CardTitle>
+                <CardDescription className="text-muted-foreground text-sm leading-relaxed">
+                  {series.description}
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="mt-auto pt-0">
+                <div className="flex flex-wrap gap-1.5 mb-4">
+                  {series.tags.map((tag, j) => (
+                    <span
+                      key={j}
+                      className="text-xs px-2 py-0.5 rounded-md bg-muted text-muted-foreground"
+                    >
+                      {tag}
+                    </span>
+                  ))}
+                </div>
+                <span className="text-primary text-sm font-medium inline-flex items-center gap-1 group-hover:gap-2 transition-all">
+                  Read series <ArrowRight className="w-3.5 h-3.5" />
+                </span>
+              </CardContent>
+            </Card>
+          </a>
+        </motion.div>
+      ))}
+    </div>
+  </section>
+)
+
+export default BlogSection

--- a/src/components/LeadershipImpact.tsx
+++ b/src/components/LeadershipImpact.tsx
@@ -1,0 +1,57 @@
+import { motion } from "framer-motion"
+import { Users } from "lucide-react"
+import SectionTitle from "./SectionTitle"
+
+type LeadershipStat = {
+  value: string
+  label: string
+  sub?: string
+}
+
+type LeadershipData = {
+  stats: LeadershipStat[]
+  highlights: string[]
+}
+
+const LeadershipImpact = ({ leadership }: { leadership: LeadershipData }) => (
+  <section>
+    <SectionTitle title="Leadership Impact" icon={Users} />
+    <div className="space-y-5">
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        {leadership.stats.map((stat, i) => (
+          <motion.div
+            key={i}
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.4, delay: i * 0.08 }}
+            className="bg-card border border-border rounded-lg p-4 text-center shadow-sm"
+          >
+            <div className="text-3xl font-bold text-primary">{stat.value}</div>
+            <div className="text-sm font-medium text-foreground mt-1">{stat.label}</div>
+            {stat.sub && (
+              <div className="text-xs text-muted-foreground mt-1">{stat.sub}</div>
+            )}
+          </motion.div>
+        ))}
+      </div>
+
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.4, delay: 0.35 }}
+        className="bg-card border border-border rounded-lg p-6 shadow-sm"
+      >
+        <ul className="space-y-3">
+          {leadership.highlights.map((highlight, i) => (
+            <li key={i} className="flex items-start gap-3 text-muted-foreground text-sm leading-relaxed">
+              <span className="mt-2 w-1.5 h-1.5 rounded-full bg-primary flex-shrink-0" />
+              {highlight}
+            </li>
+          ))}
+        </ul>
+      </motion.div>
+    </div>
+  </section>
+)
+
+export default LeadershipImpact

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -1,5 +1,5 @@
 import { motion } from "framer-motion";
-import { Code } from "lucide-react";
+import { Layers } from "lucide-react";
 import SectionTitle from "./SectionTitle";
 import {
   Card,
@@ -18,7 +18,7 @@ type Project = {
 
 const Projects = ({ projects }: { projects: Project[] }) => (
   <section>
-    <SectionTitle title="Projects" icon={Code} />
+    <SectionTitle title="Engineering Initiatives" icon={Layers} subtitle="Selected projects — framed around team, delivery, and org impact." />
     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
       {projects.map((project, index) => (
         <motion.div


### PR DESCRIPTION
## What this PR does

Repositions chaitanyamaili.in from an IC technical portfolio to an Engineering Manager candidate profile, without hiding the engineering depth that makes the transition argument credible.

## New sections

### Leadership Impact
A new section (after About) with 4 stat cards — 15 yrs experience, 10+ engineers led, 3 mentored at Pantheon (2 promoted to lead), 2+ years as cross-team tech lead — plus highlight bullets covering roadmap ownership, mentoring outcomes, quality process improvements, and stakeholder communication. Powered by a new `leadership` field in cv.json. Only renders when the field is present (safe on other branches).

### Writing
A new section (after Engineering Initiatives) showing the 3 blog series as cards: "Kubernetes API Gateway in Production" (3 parts), "Generative AI in Production" (1 part), "Open Source vs Closed LLMs" (1 part). Each card links to the series landing page with tag pills and part count. Powered by a new `blogSeries` field in cv.json. Only renders when the field is present.

## Changed sections

### Engineering Initiatives (was: Projects)
Renamed from "Projects" to "Engineering Initiatives" with a Layers icon and subtitle framing the work around team, delivery, and org impact rather than technical stack.

## cv.json changes
- Added `leadership.stats` and `leadership.highlights` fields
- Added `blogSeries` array (3 series)
- ATS fixes: British spellings → American (realising→realizing, minimise→minimize), em dashes → hyphens, contractions removed
- Quantified impact added: estimated 30% overhead reduction, 60% fewer manual release steps, 3 weeks → 2 days microsite launch time
- Added descriptions for StrApp (3 yrs) and Snyxius (1 yr) — removes HR red flag from ATS checkers
- Phone number removed (improves ATS discrimination score)
- `githubWork` field wired up in Hero.tsx with "Work" label to distinguish from personal GitHub

## Meta / SEO
- Page title: "Chaitanya Maili | Engineering Manager · Cloud Native · AI"
- All meta descriptions, og:title, og:description, twitter:title, twitter:description updated to EM framing

## Section order
Hero → About → Leadership Impact → Skills → Work Experience → Engineering Initiatives → Writing → Education → Certificates → Contact

## How to review
Deploy the branch or run `npm start` locally. The Leadership Impact and Writing sections appear between About/Skills and after Engineering Initiatives respectively. Sections gracefully absent on branches where cv.json lacks the `leadership` or `blogSeries` fields.

## Merge path
When ready to go live: merge into `new-profile` (the deployed branch).